### PR TITLE
chore: Takumi Guardの導入

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,3 @@
 engine-strict = true
 min-release-age = 7
+registry=https://npm.flatt.tech

--- a/README.md
+++ b/README.md
@@ -170,17 +170,20 @@ For security reasons, we recommend using
 For the latest security information, please refer to:
 https://nodejs.org/en/blog/vulnerability/
 
-## About the Included `.npmrc` File
+## About the `.npmrc` Included in This Template
 
-This template includes an `.npmrc` file that enables npm's `min-release-age` setting.
+This template includes a `.npmrc` file that enables npm's `min-release-age` and `registry` settings.
 
 ```ini
 min-release-age=7
+registry=https://npm.flatt.tech
 ```
 
-This setting is included as part of a supply chain security measure. It prevents npm from installing package versions that were published less than 7 days ago, helping reduce the risk of using malicious or compromised packages immediately after they are released.
+The `min-release-age` setting is enabled as part of a software supply chain security strategy. It excludes npm package versions that have been published for less than seven days from being installed. This helps reduce the risk of accidentally installing malicious or compromised packages immediately after they are published.
 
-You can adjust the `min-release-age` value or remove this setting entirely to suit your project's requirements and operational policies.
+The `registry` setting points npm to [Takumi Guard](https://flatt.tech/takumi/features/guard), an npm security proxy provided by GMO Flatt Security. During `npm install`, Takumi Guard checks packages against a database of known threats and blocks the installation of malicious packages. It works anonymously without requiring an authentication token or any additional configuration. This setting applies not only to local development, but also to dependency updates performed by GitHub Actions and Dependabot.
+
+You are free to modify these settings or remove the `.npmrc` file entirely to match your project's requirements and security policies.
 
 ---
 


### PR DESCRIPTION
## 概要

サプライチェーン攻撃対策として、npm のレジストリを [Takumi Guard](https://shisho.dev/docs/ja/t/guard/quickstart/npm/)（GMO Flatt Security が提供する npm セキュリティプロキシ）に切り替えます。`.npmrc` に `registry` を 1 行追加し、あわせて README に設定の説明を追記しました。

## 変更内容

- `.npmrc` に `registry=https://npm.flatt.tech` を追加
- README の「このテンプレートに含まれる `.npmrc` について」に `registry` 設定の説明を追記

## 背景・目的

- `npm install` / `npm ci` 時にパッケージを既知の脅威データベースと照合し、悪意のあるパッケージのインストールをブロックする
- トークンなしの匿名利用でブロック機能が有効になり、追加の設定は不要
- 既存の `min-release-age=7`（公開から7日未満のバージョンを除外）と組み合わせ、サプライチェーン攻撃への多層的な対策とする

## 影響範囲

- ローカルの `npm install` / `npm ci` がすべて `npm.flatt.tech` 経由になる
- GitHub Actions（`npm ci`）や Dependabot による依存更新にも適用される
- 既存の `package-lock.json` は、レジストリ URL ではなくインテグリティハッシュで検証されるため、そのまま利用可能（移行不要）
- アプリケーションの実行時挙動には影響なし
